### PR TITLE
[WIP] Serializing of Metrics

### DIFF
--- a/app/models/metrics/calls_received_metric.rb
+++ b/app/models/metrics/calls_received_metric.rb
@@ -1,0 +1,22 @@
+class CallsReceivedMetric < Metric
+
+  type 'calls-received'
+
+  # The total number of calls to the service. These calls should be categorised
+  # into one of four groups based on the thing that triggered the user to
+  # contact the service via the phone.
+  attribute :total
+
+  # Calls to get advice or guidance about the service.
+  attribute :get_information
+
+  # Calls to find out about a decision or action that the user expects the service to take.
+  attribute :chase_progress
+
+  # Calls to dispute an instruction or request from the service or to appeal an outcome.
+  attribute :challenge_a_decision
+
+  # Calls that don't fit into the three previous categories.
+  attribute :other
+
+end

--- a/app/models/metrics/foo_transactions_with_outcome_metric.rb
+++ b/app/models/metrics/foo_transactions_with_outcome_metric.rb
@@ -1,0 +1,7 @@
+class FooTransactionsWithOutcomeMetric < ActiveModelSerializers::Model
+  attributes :type, :total, :with_intended_outcome
+
+  def type
+    'foo-transactions-with-outcome'
+  end
+end

--- a/app/models/metrics/foo_transactions_with_outcome_metric.rb
+++ b/app/models/metrics/foo_transactions_with_outcome_metric.rb
@@ -1,5 +1,12 @@
-class FooTransactionsWithOutcomeMetric < ActiveModelSerializers::Model
-  attributes :type, :total, :with_intended_outcome
+class FooTransactionsWithOutcomeMetric
+  alias :read_attribute_for_serialization :send
+
+  attr_accessor :total, :with_intended_outcome
+
+  def initialize(attributes = {})
+    @total = attributes[:total]
+    @with_intended_outcome = attributes[:with_intended_outcome]
+  end
 
   def type
     'foo-transactions-with-outcome'

--- a/app/models/metrics/metric.rb
+++ b/app/models/metrics/metric.rb
@@ -1,0 +1,41 @@
+class Metric
+
+  def self.type(type)
+    @type = type
+  end
+
+  def self.attribute(attribute)
+    @attributes ||= []
+    @attributes << attribute
+
+    define_method(attribute) do
+      @attributes[attribute]
+    end
+  end
+
+  def self.attributes
+    @attributes
+  end
+
+  def initialize(attributes = {})
+    missing_keywords = self.class.attributes - attributes.keys
+    if missing_keywords.any?
+      keywords = missing_keywords.size == 1 ? 'keyword' : 'keywords'
+      raise ArgumentError, "missing #{keywords}: #{missing_keywords.join(', ')}"
+    end
+
+    unknown_keywords = attributes.keys - self.class.attributes
+    if unknown_keywords.any?
+      keywords = unknown_keywords.size == 1 ? 'keyword' : 'keywords'
+      raise ArgumentError, "unknown #{keywords}: #{unknown_keywords.join(', ')}"
+    end
+
+    @attributes = attributes
+  end
+
+  attr_reader :attributes
+
+  def type
+    self.class.instance_variable_get('@type')
+  end
+end

--- a/app/models/metrics/transactions_received_metric.rb
+++ b/app/models/metrics/transactions_received_metric.rb
@@ -1,0 +1,32 @@
+class TransactionsReceivedMetric < Metric
+
+  type 'transactions-received'
+
+  # Transactions are split by the channel through which they’re received.
+  # The channel is the initial method of contact even if additional information
+  # is collected in other ways afterwards.
+  # attribute :total
+
+  # Transactions received online. Doesn’t include services where you use an
+  # online tool to fill out a paper form or transactions received via web chat.
+  attribute :online
+
+  # Transactions received via the phone. Doesn’t include IVR or purely
+  # informational calls that don’t affect the outcome of a transaction.
+  attribute :phone
+
+  # Transactions received via a paper form. The form can be sent in any way
+  # including by post, email, fax or uploading.
+  attribute :paper
+
+  # The transaction must be received through a face-to-face meeting with
+  # someone working for the service. Doesn’t include handing in a paper form
+  # in person.
+  attribute :face_to_face
+
+  # Any other way the user provides the information needed to complete a
+  # transaction that doesn’t fit into the Online, Phone, Paper and
+  # Face-to-face channels.
+  attribute :other
+
+end

--- a/app/models/metrics/transactions_with_outcome_metric.rb
+++ b/app/models/metrics/transactions_with_outcome_metric.rb
@@ -1,0 +1,13 @@
+class TransactionsWithOutcomeMetric < Metric
+
+  type 'transactions-with-outcome'
+
+  # The number of transactions where no further changes to the user's
+  # relationship with government will be made in response to their request.
+  attribute :total
+
+  # A subset of the transactions ending in an outcome where the outcome is what
+  # the user set out to achieve.
+  attribute :with_intended_outcome
+
+end

--- a/app/presenters/service_data_presenter.rb
+++ b/app/presenters/service_data_presenter.rb
@@ -5,13 +5,6 @@ class ServiceDataPresenter < BasePresenter
 
   def metrics
     [
-      TransactionsReceivedMetric.new(
-        online: transactions_received_online,
-        phone: transactions_received_phone,
-        paper: transactions_received_paper,
-        face_to_face: transactions_received_face_to_face,
-        other: transactions_received_other
-      ),
       FooTransactionsWithOutcomeMetric.new(
         total: transactions_ending_any_outcome,
         with_intended_outcome: transactions_ending_user_intended_outcome

--- a/app/presenters/service_data_presenter.rb
+++ b/app/presenters/service_data_presenter.rb
@@ -3,6 +3,22 @@ class ServiceDataPresenter < BasePresenter
     @model
   end
 
+  def metrics
+    [
+      TransactionsReceivedMetric.new(
+        online: transactions_received_online,
+        phone: transactions_received_phone,
+        paper: transactions_received_paper,
+        face_to_face: transactions_received_face_to_face,
+        other: transactions_received_other
+      ),
+      TransactionsWithOutcomeMetric.new(
+        total: transactions_ending_any_outcome,
+        with_intended_outcome: transactions_ending_user_intended_outcome
+      )
+    ]
+  end
+
 	private
 	  def channel_summary
 	  	@channel_summary ||= ServiceChannelSummary.new(

--- a/app/presenters/service_data_presenter.rb
+++ b/app/presenters/service_data_presenter.rb
@@ -12,7 +12,7 @@ class ServiceDataPresenter < BasePresenter
         face_to_face: transactions_received_face_to_face,
         other: transactions_received_other
       ),
-      TransactionsWithOutcomeMetric.new(
+      FooTransactionsWithOutcomeMetric.new(
         total: transactions_ending_any_outcome,
         with_intended_outcome: transactions_ending_user_intended_outcome
       )

--- a/app/serializers/foo_transactions_with_outcome_metric_serializer.rb
+++ b/app/serializers/foo_transactions_with_outcome_metric_serializer.rb
@@ -1,0 +1,3 @@
+class FooTransactionsWithOutcomeMetricSerializer < ActiveModel::Serializer
+  attributes :type, :total, :with_intended_outcome
+end

--- a/app/serializers/metric_serializer.rb
+++ b/app/serializers/metric_serializer.rb
@@ -1,0 +1,5 @@
+class MetricSerializer < ActiveModel::Serializer
+  def attributes(requested_attrs = nil, reload = false)
+    object.attributes.reverse_merge(type: object.type)
+  end
+end

--- a/app/serializers/service_data_presenter_serializer.rb
+++ b/app/serializers/service_data_presenter_serializer.rb
@@ -1,12 +1,15 @@
 class ServiceDataPresenterSerializer < ActiveModel::Serializer
-  attributes :service,
-             :transactions_received_online,
-             :transactions_received_phone,
-             :transactions_received_paper,
-             :transactions_received_face_to_face,
-             :transactions_received_other,
-             :transactions_ending_any_outcome,
-             :transactions_ending_user_intended_outcome
+  attributes :service# ,
+#              :transactions_received_online,
+#              :transactions_received_phone,
+#              :transactions_received_paper,
+#              :transactions_received_face_to_face,
+#              :transactions_received_other,
+#              :transactions_ending_any_outcome,
+#              :transactions_ending_user_intended_outcome
+
+  has_many :metrics, serializer: MetricSerializer
 
   belongs_to :service
+
 end

--- a/app/serializers/service_data_presenter_serializer.rb
+++ b/app/serializers/service_data_presenter_serializer.rb
@@ -8,7 +8,7 @@ class ServiceDataPresenterSerializer < ActiveModel::Serializer
 #              :transactions_ending_any_outcome,
 #              :transactions_ending_user_intended_outcome
 
-  has_many :metrics, serializer: MetricSerializer
+  has_many :metrics
 
   belongs_to :service
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,8 @@ module CgsdApiRails
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+
+    config.autoload_paths << Rails.root.join('app', 'models', 'metrics')
   end
 end


### PR DESCRIPTION
This branch shows what I was proposing regarding serialising metrics as distinct objects, rather than inline in the object. I think the advantage of this is easier deserialisation in the client, and also clearer relationships between the individual fields.

This changes the API output from:

```json
[
   {
      "service" : {
         "hostname" : "carersallowance",
         "natural_key" : 1018,
         "natural_name" : "Carers Allowance"
      },
      "transactions_received_paper" : 10000,
      "transactions_ending_any_outcome" : 585010,
      "transactions_received_phone" : 25977,
      "transactions_ending_user_intended_outcome" : 25977,
      "transactions_received_online" : 765010,
      "transactions_received_other" : null,
      "transactions_received_face_to_face" : 2000
   },
   {
      "transactions_ending_any_outcome" : 976000,
      "transactions_received_paper" : null,
      "service" : {
         "natural_key" : 1148,
         "hostname" : "universalcredit",
         "natural_name" : "Universal Credit"
      },
      "transactions_received_face_to_face" : null,
      "transactions_received_online" : 1965010,
      "transactions_received_other" : null,
      "transactions_ending_user_intended_outcome" : 89977,
      "transactions_received_phone" : 65977
   }
]
```

to:

```json
[
  {
    "service": {
      "natural_key": 1018,
      "natural_name": "Carers Allowance",
      "hostname": "carersallowance"
    },
    "metrics": [
      {
        "type": "transactions-received",
        "online": 765010,
        "phone": 25977,
        "paper": 10000,
        "face_to_face": 2000,
        "other": null
      },
      {
        "type": "transactions-with-outcome",
        "total": 585010,
        "with_intended_outcome": 25977
      }
    ]
  },
  {
    "service": {
      "natural_key": 1148,
      "natural_name": "Universal Credit",
      "hostname": "universalcredit"
    },
    "metrics": [
      {
        "type": "transactions-received",
        "online": 1965010.0,
        "phone": 65977,
        "paper": null,
        "face_to_face": null,
        "other": null
      },
      {
        "type": "transactions-with-outcome",
        "total": 976000,
        "with_intended_outcome": 89977
      }
    ]
  }
]
```

I used some meta-programming as I thought it made the metrics, and their attributes more self-documenting. Although I'm not sure the trade-off with the complexity is worth it here.